### PR TITLE
Create ASP.NET Core 8 API using the latest Elasticsearch client

### DIFF
--- a/ElasticsearchWebApi.Core/Controllers/SearchController.cs
+++ b/ElasticsearchWebApi.Core/Controllers/SearchController.cs
@@ -1,0 +1,112 @@
+using ElasticsearchWebApi.Core.Models;
+using ElasticsearchWebApi.Core.Models.Requests;
+using ElasticsearchWebApi.Core.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ElasticsearchWebApi.Core.Controllers;
+
+[ApiController]
+[Route("api")]
+public class SearchController : ControllerBase
+{
+    private readonly ISearchService<Post> _searchService;
+    private readonly ElasticIndexService _indexService;
+
+    public SearchController(ISearchService<Post> searchService, ElasticIndexService indexService)
+    {
+        _searchService = searchService;
+        _indexService = indexService;
+    }
+
+    [HttpGet("search")]
+    [ProducesResponseType(typeof(SearchResult<Post>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Search([FromQuery(Name = "q")] string query, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return BadRequest("Query parameter 'q' is required.");
+        }
+
+        var result = await _searchService.SearchAsync(query, page, pageSize);
+        return Ok(result);
+    }
+
+    [HttpGet("index")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Index([FromQuery] string fileName, [FromQuery] int maxItems = 1000)
+    {
+        await _indexService.CreateIndexAsync(fileName, maxItems);
+        return Ok();
+    }
+
+    [HttpGet("autocomplete")]
+    [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Autocomplete([FromQuery(Name = "q")] string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return BadRequest("Query parameter 'q' is required.");
+        }
+
+        var suggestions = await _searchService.AutocompleteAsync(query);
+        return Ok(suggestions);
+    }
+
+    [HttpGet("suggest")]
+    [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Suggest([FromQuery(Name = "q")] string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return BadRequest("Query parameter 'q' is required.");
+        }
+
+        var suggestions = await _searchService.SuggestAsync(query);
+        return Ok(suggestions);
+    }
+
+    [HttpGet("morelikethis")]
+    [ProducesResponseType(typeof(SearchResult<Post>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> MoreLikeThis([FromQuery] string id, [FromQuery] int pageSize = 3)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return BadRequest("Parameter 'id' is required.");
+        }
+
+        var result = await _searchService.FindMoreLikeThisAsync(id, pageSize);
+        return Ok(result);
+    }
+
+    [HttpPost("searchbycategory")]
+    [ProducesResponseType(typeof(SearchResult<Post>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> SearchByCategory([FromBody] CategorySearchRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var result = await _searchService.SearchByCategoryAsync(request.Query, request.Categories, request.Page, request.PageSize);
+        return Ok(result);
+    }
+
+    [HttpGet("get")]
+    [ProducesResponseType(typeof(Post), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromQuery] string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return BadRequest("Parameter 'id' is required.");
+        }
+
+        var result = await _searchService.GetAsync(id);
+        if (result is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result);
+    }
+}

--- a/ElasticsearchWebApi.Core/ElasticsearchWebApi.Core.csproj
+++ b/ElasticsearchWebApi.Core/ElasticsearchWebApi.Core.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.13.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/ElasticsearchWebApi.Core/Models/PageResult.cs
+++ b/ElasticsearchWebApi.Core/Models/PageResult.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace ElasticsearchWebApi.Core.Models;
+
+public class PageResult<T>
+{
+    [JsonPropertyName("total")]
+    public int Total { get; set; }
+        = 0;
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+        = 1;
+
+    [JsonPropertyName("data")]
+    public IEnumerable<T> Data { get; set; }
+        = Array.Empty<T>();
+}

--- a/ElasticsearchWebApi.Core/Models/Post.cs
+++ b/ElasticsearchWebApi.Core/Models/Post.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace ElasticsearchWebApi.Core.Models;
+
+public class Post
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("creationDate")]
+    public DateTime? CreationDate { get; set; }
+        = null;
+
+    [JsonPropertyName("score")]
+    public int? Score { get; set; }
+        = null;
+
+    [JsonPropertyName("answerCount")]
+    public int? AnswerCount { get; set; }
+        = null;
+
+    [JsonPropertyName("body")]
+    public string? Body { get; set; }
+        = null;
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+        = null;
+
+    [JsonPropertyName("tags")]
+    public IEnumerable<string>? Tags { get; set; }
+        = null;
+
+    [JsonPropertyName("suggest")]
+    public IEnumerable<string>? Suggest { get; set; }
+        = null;
+}

--- a/ElasticsearchWebApi.Core/Models/Requests/CategorySearchRequest.cs
+++ b/ElasticsearchWebApi.Core/Models/Requests/CategorySearchRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace ElasticsearchWebApi.Core.Models.Requests;
+
+public class CategorySearchRequest
+{
+    [Required]
+    [JsonPropertyName("q")]
+    public string Query { get; set; } = string.Empty;
+
+    [JsonPropertyName("categories")]
+    public IEnumerable<string> Categories { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("page")]
+    [Range(1, int.MaxValue)]
+    public int Page { get; set; } = 1;
+
+    [JsonPropertyName("pageSize")]
+    [Range(1, 1000)]
+    public int PageSize { get; set; } = 10;
+}

--- a/ElasticsearchWebApi.Core/Models/SearchResult.cs
+++ b/ElasticsearchWebApi.Core/Models/SearchResult.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace ElasticsearchWebApi.Core.Models;
+
+public class SearchResult<T>
+{
+    [JsonPropertyName("total")]
+    public int Total { get; set; }
+        = 0;
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+        = 1;
+
+    [JsonPropertyName("pageSize")]
+    public int PageSize { get; set; }
+        = 0;
+
+    [JsonPropertyName("results")]
+    public IEnumerable<T> Results { get; set; }
+        = Array.Empty<T>();
+
+    [JsonPropertyName("elapsedMilliseconds")]
+    public long ElapsedMilliseconds { get; set; }
+        = 0;
+
+    [JsonPropertyName("aggregationsByTags")]
+    public IDictionary<string, long> AggregationsByTags { get; set; }
+        = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+}

--- a/ElasticsearchWebApi.Core/Program.cs
+++ b/ElasticsearchWebApi.Core/Program.cs
@@ -1,0 +1,76 @@
+using Elastic.Clients.Elasticsearch;
+using Elastic.Transport;
+using ElasticsearchWebApi.Core.Models;
+using ElasticsearchWebApi.Core.Services;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.Configure<ElasticOptions>(builder.Configuration.GetSection("Elasticsearch"));
+
+builder.Services.AddSingleton(sp =>
+{
+    var options = sp.GetRequiredService<IOptions<ElasticOptions>>().Value;
+    if (string.IsNullOrWhiteSpace(options.Uri))
+    {
+        throw new InvalidOperationException("Elasticsearch:Uri configuration value is required.");
+    }
+
+    var settings = new ElasticsearchClientSettings(new Uri(options.Uri))
+        .DefaultIndex(options.IndexName)
+        .EnableApiVersioningHeader();
+
+    if (!string.IsNullOrWhiteSpace(options.Username) && !string.IsNullOrWhiteSpace(options.Password))
+    {
+        settings = settings.Authentication(new BasicAuthentication(options.Username, options.Password));
+    }
+
+    if (options.DisableDirectStreaming)
+    {
+        settings = settings.DisableDirectStreaming();
+    }
+
+    if (options.CertificateFingerprint is { Length: > 0 })
+    {
+        settings = settings.CertificateFingerprint(options.CertificateFingerprint);
+    }
+
+    return new ElasticsearchClient(settings);
+});
+
+builder.Services.AddSingleton<ElasticIndexService>();
+builder.Services.AddScoped<ISearchService<Post>, ElasticSearchService>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapControllers();
+
+app.Run();
+
+namespace ElasticsearchWebApi.Core
+{
+    public partial class Program
+    {
+    }
+}

--- a/ElasticsearchWebApi.Core/Properties/launchSettings.json
+++ b/ElasticsearchWebApi.Core/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "ElasticsearchWebApi.Core": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7126;http://localhost:5126",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ElasticsearchWebApi.Core/Services/ElasticIndexService.cs
+++ b/ElasticsearchWebApi.Core/Services/ElasticIndexService.cs
@@ -1,0 +1,158 @@
+using Elastic.Clients.Elasticsearch;
+using ElasticsearchWebApi.Core.Models;
+using ElasticsearchWebApi.Core.Utils;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace ElasticsearchWebApi.Core.Services;
+
+public class ElasticIndexService
+{
+    private readonly ElasticsearchClient _client;
+    private readonly ElasticOptions _options;
+    private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<ElasticIndexService> _logger;
+
+    public ElasticIndexService(
+        ElasticsearchClient client,
+        IOptions<ElasticOptions> options,
+        IWebHostEnvironment environment,
+        ILogger<ElasticIndexService> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _environment = environment;
+        _logger = logger;
+    }
+
+    public async Task CreateIndexAsync(string fileName, int maxItems)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("File name must be provided.", nameof(fileName));
+        }
+
+        await EnsureIndexExistsAsync();
+
+        var dataPath = Path.Combine(_environment.ContentRootPath, "data", fileName);
+
+        if (!File.Exists(dataPath))
+        {
+            throw new FileNotFoundException($"Could not locate the data file '{fileName}' in the data directory.", dataPath);
+        }
+
+        await BulkIndexAsync(dataPath, maxItems <= 0 ? int.MaxValue : maxItems);
+    }
+
+    private async Task EnsureIndexExistsAsync()
+    {
+        var exists = await _client.Indices.ExistsAsync(_options.IndexName);
+        if (exists.Exists)
+        {
+            return;
+        }
+
+        var response = await _client.Indices.CreateAsync(_options.IndexName, c => c
+            .Mappings(ms => ms
+                .Properties<Post>(ps => ps
+                    .Keyword(k => k.Field(f => f.Id))
+                    .Date(d => d.Field(f => f.CreationDate))
+                    .Number(n => n.Field(f => f.Score))
+                    .Number(n => n.Field(f => f.AnswerCount))
+                    .Text(t => t.Field(f => f.Body))
+                    .Text(t => t.Field(f => f.Title))
+                    .Keyword(k => k.Field(f => f.Tags))
+                    .Completion(co => co.Field(f => f.Suggest))
+                )
+            )
+        );
+
+        if (!response.IsValidResponse)
+        {
+            throw new InvalidOperationException($"Failed to create index '{_options.IndexName}'. Details: {response.DebugInformation}");
+        }
+    }
+
+    private IEnumerable<Post> LoadPostsFromFile(string inputPath)
+    {
+        using var reader = XmlReader.Create(inputPath, new XmlReaderSettings { Async = false });
+        reader.MoveToContent();
+        while (reader.Read())
+        {
+            if (reader.NodeType != XmlNodeType.Element || reader.Name != "row")
+            {
+                continue;
+            }
+
+            if (!string.Equals(reader.GetAttribute("PostTypeId"), "1", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (XNode.ReadFrom(reader) is not XElement element)
+            {
+                continue;
+            }
+
+            var post = new Post
+            {
+                Id = element.Attribute("Id")?.Value ?? Guid.NewGuid().ToString("N"),
+                Title = element.Attribute("Title")?.Value ?? string.Empty,
+                CreationDate = DateTime.TryParse(element.Attribute("CreationDate")?.Value, out var created)
+                    ? created
+                    : null,
+                Score = int.TryParse(element.Attribute("Score")?.Value, out var score)
+                    ? score
+                    : null,
+                Body = HtmlRemoval.StripTagsRegex(element.Attribute("Body")?.Value ?? string.Empty),
+                Tags = ParseTags(element.Attribute("Tags")?.Value),
+                AnswerCount = int.TryParse(element.Attribute("AnswerCount")?.Value, out var answers)
+                    ? answers
+                    : null
+            };
+
+            post.Suggest = post.Tags?.ToArray();
+
+            yield return post;
+        }
+    }
+
+    private async Task BulkIndexAsync(string path, int maxItems)
+    {
+        var indexed = 0;
+        foreach (var post in LoadPostsFromFile(path).Take(maxItems))
+        {
+            var response = await _client.IndexAsync(post, i => i.Index(_options.IndexName).Id(post.Id));
+            if (!response.IsValidResponse)
+            {
+                _logger.LogWarning("Failed to index document {DocumentId}. Debug information: {DebugInformation}", post.Id, response.DebugInformation);
+            }
+            else
+            {
+                indexed++;
+            }
+        }
+
+        _logger.LogInformation("Indexed {Count} documents into '{IndexName}'", indexed, _options.IndexName);
+    }
+
+    private static IEnumerable<string>? ParseTags(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var sanitized = value
+            .Replace("><", "|", StringComparison.Ordinal)
+            .Replace("<", string.Empty, StringComparison.Ordinal)
+            .Replace(">", string.Empty, StringComparison.Ordinal)
+            .Replace("&gt;&lt;", "|", StringComparison.Ordinal)
+            .Replace("&lt;", string.Empty, StringComparison.Ordinal)
+            .Replace("&gt;", string.Empty, StringComparison.Ordinal);
+
+        return sanitized.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/ElasticsearchWebApi.Core/Services/ElasticOptions.cs
+++ b/ElasticsearchWebApi.Core/Services/ElasticOptions.cs
@@ -1,0 +1,22 @@
+namespace ElasticsearchWebApi.Core.Services;
+
+public class ElasticOptions
+{
+    public const string SectionName = "Elasticsearch";
+
+    public string Uri { get; set; } = "http://localhost:9200";
+
+    public string IndexName { get; set; } = "posts";
+
+    public string? Username { get; set; }
+        = null;
+
+    public string? Password { get; set; }
+        = null;
+
+    public string? CertificateFingerprint { get; set; }
+        = null;
+
+    public bool DisableDirectStreaming { get; set; }
+        = false;
+}

--- a/ElasticsearchWebApi.Core/Services/ElasticSearchService.cs
+++ b/ElasticsearchWebApi.Core/Services/ElasticSearchService.cs
@@ -1,0 +1,237 @@
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Aggregations;
+using Elastic.Clients.Elasticsearch.Core.Search;
+using Elastic.Clients.Elasticsearch.QueryDsl;
+using ElasticsearchWebApi.Core.Models;
+using Microsoft.Extensions.Options;
+
+namespace ElasticsearchWebApi.Core.Services;
+
+public class ElasticSearchService : ISearchService<Post>
+{
+    private readonly ElasticsearchClient _client;
+    private readonly ElasticOptions _options;
+    private readonly ILogger<ElasticSearchService> _logger;
+
+    public ElasticSearchService(
+        ElasticsearchClient client,
+        IOptions<ElasticOptions> options,
+        ILogger<ElasticSearchService> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<SearchResult<Post>> SearchAsync(string query, int page, int pageSize)
+    {
+        var response = await _client.SearchAsync<Post>(s => s
+            .Index(_options.IndexName)
+            .From(Math.Max(page - 1, 0) * pageSize)
+            .Size(pageSize)
+            .Query(q => q
+                .MultiMatch(mm => mm
+                    .Query(query)
+                    .Fields(new[] { "title", "body", "tags" })
+                )
+            )
+            .Aggregations(a => a
+                .Terms("by_tags", t => t
+                    .Field(f => f.Tags)
+                    .Size(10)
+                )
+            )
+        );
+
+        EnsureValidResponse(response, nameof(SearchAsync));
+
+        return BuildSearchResult(page, pageSize, response);
+    }
+
+    public async Task<SearchResult<Post>> SearchByCategoryAsync(string query, IEnumerable<string> tags, int page, int pageSize)
+    {
+        var tagFilters = tags?.Where(tag => !string.IsNullOrWhiteSpace(tag)).ToArray() ?? Array.Empty<string>();
+
+        var response = await _client.SearchAsync<Post>(s => s
+            .Index(_options.IndexName)
+            .From(Math.Max(page - 1, 0) * pageSize)
+            .Size(pageSize)
+            .Query(q => q
+                .Bool(b =>
+                    b.Must(m => m
+                        .MultiMatch(mm => mm
+                            .Query(query)
+                            .Fields(new[] { "title", "body", "tags" })
+                        )
+                    )
+                    .Filter(f => f
+                        .Bool(inner => inner
+                            .Must(tagFilters
+                                .Select<Func<QueryDescriptor<Post>, Query>>(tag => fq => fq.Term(t => t
+                                    .Field(ff => ff.Tags)
+                                    .Value(tag)
+                                ))
+                                .ToArray())
+                        )
+                    )
+                )
+            )
+            .Aggregations(a => a
+                .Terms("by_tags", t => t
+                    .Field(f => f.Tags)
+                    .Size(10)
+                )
+            )
+        );
+
+        EnsureValidResponse(response, nameof(SearchByCategoryAsync));
+
+        return BuildSearchResult(page, pageSize, response);
+    }
+
+    public async Task<IEnumerable<string>> AutocompleteAsync(string query)
+    {
+        var response = await _client.SearchAsync<Post>(s => s
+            .Index(_options.IndexName)
+            .Size(0)
+            .Suggest(su => su
+                .Completion("tag-suggestions", c => c
+                    .Field(f => f.Suggest)
+                    .Prefix(query)
+                    .SkipDuplicates()
+                    .Size(6)
+                )
+            )
+        );
+
+        EnsureValidResponse(response, nameof(AutocompleteAsync));
+
+        if (!response.Suggest.TryGetValue("tag-suggestions", out var suggestions))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return suggestions
+            .SelectMany(s => s.Options)
+            .Select(o => o.Text)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<IEnumerable<string>> SuggestAsync(string query)
+    {
+        var response = await _client.SearchAsync<Post>(s => s
+            .Index(_options.IndexName)
+            .Size(0)
+            .Suggest(su => su
+                .Term("post-suggestions", t => t
+                    .Text(query)
+                    .Field(f => f.Body)
+                    .Field(f => f.Title)
+                    .Field(f => f.Tags)
+                    .Size(6)
+                )
+            )
+        );
+
+        EnsureValidResponse(response, nameof(SuggestAsync));
+
+        if (!response.Suggest.TryGetValue("post-suggestions", out var suggestions))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return suggestions
+            .SelectMany(s => s.Options)
+            .Select(o => o.Text)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<SearchResult<Post>> FindMoreLikeThisAsync(string id, int pageSize)
+    {
+        var response = await _client.SearchAsync<Post>(s => s
+            .Index(_options.IndexName)
+            .Size(pageSize)
+            .Query(q => q
+                .MoreLikeThis(mlt => mlt
+                    .Like(l => l.Document(d => d.Id(id)))
+                    .Fields(new[] { "title", "body", "tags" })
+                    .MinTermFrequency(1)
+                )
+            )
+        );
+
+        EnsureValidResponse(response, nameof(FindMoreLikeThisAsync));
+
+        return BuildSearchResult(1, pageSize, response);
+    }
+
+    public async Task<Post?> GetAsync(string id)
+    {
+        var response = await _client.GetAsync<Post>(id, g => g.Index(_options.IndexName));
+
+        if (!response.IsValidResponse)
+        {
+            _logger.LogWarning("Failed to fetch document {DocumentId} from Elasticsearch. Reason: {DebugInformation}", id, response.DebugInformation);
+            return default;
+        }
+
+        return response.Source;
+    }
+
+    private void EnsureValidResponse(SearchResponse<Post> response, string operation)
+    {
+        if (response.IsValidResponse)
+        {
+            return;
+        }
+
+        _logger.LogError("Elasticsearch {Operation} operation failed. Debug information: {DebugInformation}", operation, response.DebugInformation);
+        throw new InvalidOperationException($"Elasticsearch {operation} operation failed.");
+    }
+
+    private SearchResult<Post> BuildSearchResult(int page, int pageSize, SearchResponse<Post> response)
+    {
+        var total = response.HitsMetadata?.Total?.Value ?? response.Documents.Count;
+        var aggregations = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        if (response.Aggregations is { } aggs && aggs.TryGetValue("by_tags", out var aggregate))
+        {
+            switch (aggregate)
+            {
+                case StringTermsAggregate stringTerms:
+                    foreach (var bucket in stringTerms.Buckets)
+                    {
+                        if (!string.IsNullOrEmpty(bucket.Key))
+                        {
+                            aggregations[bucket.Key] = bucket.DocCount ?? 0;
+                        }
+                    }
+                    break;
+                case TermsAggregate terms:
+                    foreach (var bucket in terms.Buckets)
+                    {
+                        var key = bucket.KeyAsString ?? bucket.Key?.ToString();
+                        if (!string.IsNullOrEmpty(key))
+                        {
+                            aggregations[key] = bucket.DocCount ?? 0;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return new SearchResult<Post>
+        {
+            Total = (int)total,
+            Page = page,
+            PageSize = pageSize,
+            Results = response.Documents.ToArray(),
+            ElapsedMilliseconds = response.Took,
+            AggregationsByTags = aggregations
+        };
+    }
+}

--- a/ElasticsearchWebApi.Core/Services/ISearchService.cs
+++ b/ElasticsearchWebApi.Core/Services/ISearchService.cs
@@ -1,0 +1,18 @@
+using ElasticsearchWebApi.Core.Models;
+
+namespace ElasticsearchWebApi.Core.Services;
+
+public interface ISearchService<T>
+{
+    Task<SearchResult<T>> SearchAsync(string query, int page, int pageSize);
+
+    Task<SearchResult<T>> SearchByCategoryAsync(string query, IEnumerable<string> tags, int page, int pageSize);
+
+    Task<IEnumerable<string>> AutocompleteAsync(string query);
+
+    Task<IEnumerable<string>> SuggestAsync(string query);
+
+    Task<SearchResult<T>> FindMoreLikeThisAsync(string id, int pageSize);
+
+    Task<T?> GetAsync(string id);
+}

--- a/ElasticsearchWebApi.Core/Utils/Extensions.cs
+++ b/ElasticsearchWebApi.Core/Utils/Extensions.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+
+namespace ElasticsearchWebApi.Core.Utils;
+
+public static class EnumerableExtensions
+{
+    public static IEnumerable<IReadOnlyCollection<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size));
+        }
+
+        var bucket = new List<TSource>(size);
+        foreach (var item in source)
+        {
+            bucket.Add(item);
+            if (bucket.Count == size)
+            {
+                yield return bucket.ToArray();
+                bucket.Clear();
+            }
+        }
+
+        if (bucket.Count > 0)
+        {
+            yield return bucket.ToArray();
+        }
+    }
+}
+
+public static class HtmlRemoval
+{
+    private static readonly Regex HtmlRegex = new("<.*?>", RegexOptions.Compiled);
+
+    public static string StripTagsRegex(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return string.Empty;
+        }
+
+        return HtmlRegex.Replace(source, string.Empty);
+    }
+}

--- a/ElasticsearchWebApi.Core/appsettings.Development.json
+++ b/ElasticsearchWebApi.Core/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ElasticsearchWebApi.Core/appsettings.json
+++ b/ElasticsearchWebApi.Core/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Elasticsearch": {
+    "Uri": "http://localhost:9200",
+    "IndexName": "stackoverflow-posts"
+  }
+}

--- a/elasticsearch-nest-webapi-angularjs.sln
+++ b/elasticsearch-nest-webapi-angularjs.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "elasticsearch-nest-webapi-angularjs", "elasticsearch-nest-webapi-angularjs\elasticsearch-nest-webapi-angularjs.csproj", "{8FDA78B9-38D3-4284-86CB-6F533716FB90}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElasticsearchWebApi.Core", "ElasticsearchWebApi.Core\ElasticsearchWebApi.Core.csproj", "{F2D7EDEC-AE19-4F97-97CB-F358DEA3A04C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElasticsearchWebApi.IntegrationTests", "tests\ElasticsearchWebApi.IntegrationTests\ElasticsearchWebApi.IntegrationTests.csproj", "{7E4FBC19-3001-4A0C-BBDC-606E516EE49C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +19,14 @@ Global
 		{8FDA78B9-38D3-4284-86CB-6F533716FB90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FDA78B9-38D3-4284-86CB-6F533716FB90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FDA78B9-38D3-4284-86CB-6F533716FB90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2D7EDEC-AE19-4F97-97CB-F358DEA3A04C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2D7EDEC-AE19-4F97-97CB-F358DEA3A04C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2D7EDEC-AE19-4F97-97CB-F358DEA3A04C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2D7EDEC-AE19-4F97-97CB-F358DEA3A04C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E4FBC19-3001-4A0C-BBDC-606E516EE49C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E4FBC19-3001-4A0C-BBDC-606E516EE49C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E4FBC19-3001-4A0C-BBDC-606E516EE49C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E4FBC19-3001-4A0C-BBDC-606E516EE49C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/ElasticsearchWebApi.IntegrationTests/ElasticsearchWebApi.IntegrationTests.csproj
+++ b/tests/ElasticsearchWebApi.IntegrationTests/ElasticsearchWebApi.IntegrationTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ElasticsearchWebApi.Core\ElasticsearchWebApi.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ElasticsearchWebApi.IntegrationTests/ElasticsearchWebApplicationFactory.cs
+++ b/tests/ElasticsearchWebApi.IntegrationTests/ElasticsearchWebApplicationFactory.cs
@@ -1,0 +1,30 @@
+using Elastic.Clients.Elasticsearch;
+using ElasticsearchWebApi.Core;
+using ElasticsearchWebApi.Core.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ElasticsearchWebApi.IntegrationTests;
+
+public class ElasticsearchWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public string IndexName { get; } = $"test-posts-{Guid.NewGuid():N}";
+
+    public Uri ElasticsearchUri { get; }
+        = new(Environment.GetEnvironmentVariable("ELASTICSEARCH_URL") ?? "http://localhost:9200");
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((context, configBuilder) =>
+        {
+            var overrides = new Dictionary<string, string?>
+            {
+                [$"{ElasticOptions.SectionName}:Uri"] = ElasticsearchUri.ToString(),
+                [$"{ElasticOptions.SectionName}:IndexName"] = IndexName
+            };
+
+            configBuilder.AddInMemoryCollection(overrides);
+        });
+    }
+}

--- a/tests/ElasticsearchWebApi.IntegrationTests/SearchEndpointsTests.cs
+++ b/tests/ElasticsearchWebApi.IntegrationTests/SearchEndpointsTests.cs
@@ -1,0 +1,130 @@
+using System.Net.Http.Json;
+using Elastic.Clients.Elasticsearch;
+using ElasticsearchWebApi.Core.Models;
+using ElasticsearchWebApi.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Xunit.Sdk;
+
+namespace ElasticsearchWebApi.IntegrationTests;
+
+public class SearchEndpointsTests : IAsyncLifetime
+{
+    private readonly ElasticsearchWebApplicationFactory _factory = new();
+    private ElasticsearchClient? _client;
+    private ElasticOptions? _options;
+
+    public async Task InitializeAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        _client = scope.ServiceProvider.GetRequiredService<ElasticsearchClient>();
+        _options = scope.ServiceProvider.GetRequiredService<IOptions<ElasticOptions>>().Value;
+
+        if (!await IsElasticsearchAvailableAsync(_client))
+        {
+            throw new SkipException("Elasticsearch instance is not available. Set ELASTICSEARCH_URL to a running 8.x cluster to run integration tests.");
+        }
+
+        await CleanupIndexAsync();
+        await EnsureTestIndexAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null && _options is not null)
+        {
+            await CleanupIndexAsync();
+        }
+
+        _factory.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task SearchEndpoint_ReturnsIndexedDocument()
+    {
+        Assert.NotNull(_client);
+        Assert.NotNull(_options);
+
+        var post = new Post
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Title = "integration test",
+            Body = "integration test body",
+            Tags = new[] { "integration", "tests" },
+            Suggest = new[] { "integration", "tests" },
+            CreationDate = DateTime.UtcNow,
+            Score = 5,
+            AnswerCount = 1
+        };
+
+        var indexResponse = await _client!.IndexAsync(post, i => i.Index(_options!.IndexName).Id(post.Id));
+        Assert.True(indexResponse.IsValidResponse, indexResponse.DebugInformation);
+
+        await _client.Indices.RefreshAsync(_options.IndexName);
+
+        var httpClient = _factory.CreateClient();
+        var response = await httpClient.GetAsync($"api/search?q={Uri.EscapeDataString("integration")}");
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<SearchResult<Post>>();
+        Assert.NotNull(result);
+        Assert.True(result!.Total >= 1);
+        Assert.Contains(result.Results, r => string.Equals(r.Id, post.Id, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task EnsureTestIndexAsync()
+    {
+        if (_client is null || _options is null)
+        {
+            return;
+        }
+
+        var exists = await _client.Indices.ExistsAsync(_options.IndexName);
+        if (exists.Exists)
+        {
+            return;
+        }
+
+        var response = await _client.Indices.CreateAsync(_options.IndexName, c => c
+            .Mappings(ms => ms
+                .Properties<Post>(ps => ps
+                    .Keyword(k => k.Field(f => f.Id))
+                    .Date(d => d.Field(f => f.CreationDate))
+                    .Number(n => n.Field(f => f.Score))
+                    .Number(n => n.Field(f => f.AnswerCount))
+                    .Text(t => t.Field(f => f.Body))
+                    .Text(t => t.Field(f => f.Title))
+                    .Keyword(k => k.Field(f => f.Tags))
+                    .Completion(co => co.Field(f => f.Suggest))
+                )
+            )
+        );
+
+        Assert.True(response.IsValidResponse, response.DebugInformation);
+    }
+
+    private async Task CleanupIndexAsync()
+    {
+        if (_client is null || _options is null)
+        {
+            return;
+        }
+
+        await _client.Indices.DeleteAsync(_options.IndexName, d => d.IgnoreUnavailable(true));
+    }
+
+    private static async Task<bool> IsElasticsearchAvailableAsync(ElasticsearchClient client)
+    {
+        try
+        {
+            var ping = await client.PingAsync();
+            return ping.IsValidResponse;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new ASP.NET Core 8 Web API project alongside the legacy application with modern dependency injection and configuration
- reimplement Elasticsearch services, controllers, and models against Elastic.Clients.Elasticsearch with System.Text.Json serialization
- introduce an integration test project that boots the new API and exercises search scenarios against an Elasticsearch 8.x cluster when available

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fff8dfb05c832ea6267c7b86d0f125